### PR TITLE
add rich snippet info, improve meta

### DIFF
--- a/_includes/article.html
+++ b/_includes/article.html
@@ -33,13 +33,13 @@
   {% endif %}
 
   <footer>
-    <p>
+    <p class="vcard">
       {% if index %}
-      <img data-author-email="{{ post.author_email }}" alt="{{ post.author }}" />
-      <span>&mdash;</span> {{ post.author }}
+      <img class="photo" data-author-email="{{ post.author_email }}" alt="{{ post.author }}" />
+      <span class="dash">&mdash;</span> <span class="fn">{{ post.author }}</span>
       {% else %}
-      <img data-author-email="{{ page.author_email }}" alt="{{ page.author }}" />
-      <span>&mdash;</span> {{ page.author }}
+      <img class="photo" data-author-email="{{ page.author_email }}" alt="{{ page.author }}" />
+      <span class="dash">&mdash;</span> <span class="fn">{{ page.author }}</span>
       {% endif %}
     </p>
   </footer>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,12 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {% if index %}
+    <meta name="description" content="The blog, for RubyGems!" />
+    <title>RubyGems.org</title>
+    {% else %}
     <title>{{ page.title }} | RubyGems.org</title>
+    {% endif %}
     <link rel="shortcut icon" href="http://rubygems.org/favicon.ico" type="image/x-icon">
     <link href="/atom.xml" rel="alternate" title="RSS" type="application/rss+xml" />
     <link href="/stylesheets/application.css" type="text/css" rel="stylesheet" />

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -797,7 +797,7 @@ article {
               font-size: 90%;
               line-height: 30px;
               margin: 0; }
-              .other-posts .content-index li a article footer p span {
+              .other-posts .content-index li a article footer p span.dash {
                 display: none; }
               .other-posts .content-index li a article footer p img {
                 height: 30px;

--- a/stylesheets/scss/_archive.scss
+++ b/stylesheets/scss/_archive.scss
@@ -98,7 +98,7 @@
               line-height: 30px;
               margin: 0;
 
-              span {
+              span.dash {
                 display: none;
               }
 


### PR DESCRIPTION
- ref for rich snippet: http://support.google.com/webmasters/bin/answer.py\?hl\=en\&answer\=146646
- ref for meta: http://support.google.com/webmasters/bin/answer.py\?hl\=en\&answer\=35624\#1

Not putting a meta desc into post pages for now so that google just uses the post excerpt. 
