### PR TITLE
ff-meta-serif-web-pro does not support East Asian characters.

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -513,7 +513,7 @@ a {
     color: #300405; }
 
 p, li {
-  font-family: "ff-meta-serif-web-pro", serif;
+  font-family: serif;
   font-size: 120%;
   font-weight: 500; }
 


### PR DESCRIPTION
![screenshot_2013-08-23-19-03-23](https://f.cloud.github.com/assets/2240638/1015838/0f6fafda-0be8-11e3-87ab-3e5f811fb471.png)
![screenshot_2013-08-23-18-02-10](https://f.cloud.github.com/assets/2240638/1015839/1631d1d6-0be8-11e3-903b-397bb9ef9088.png)
