### PR TITLE
Remove misplaced attribute

### DIFF
--- a/_posts/2013-12-26-2.2.0-released.md
+++ b/_posts/2013-12-26-2.2.0-released.md
@@ -5,7 +5,7 @@ author: Eric Hodel
 author_email: drbrain@segment7.net
 ---
 
-RubyGems 2.2.0 includes special thanks to vt ondruch and michal papis for testing and finding bugs in, rubygems as it was prepared for the  release, major enhancements, minor enhancements and bug fixes.
+RubyGems 2.2.0 includes major enhancements, minor enhancements and bug fixes.
 
 To update to the latest RubyGems you can run:
 


### PR DESCRIPTION
It looks like this attribution got put in the wrong spot. It's already include below.
