### PR TITLE
Update starting jekyll documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Setup
 
 Make sure you have jekyll installed (`gem install bundler; bundle`), and run:
 
-    $ jekyll --server
+    $ jekyll serve
 
 The pages will be available at http://localhost:4000/
 


### PR DESCRIPTION
$:~/git_repo/rubygems.github.com$ jekyll --server
       Deprecation: Jekyll now uses subcommands instead of just switches. Run `jekyll help' to find out more.
       Deprecation: The --server command has been replaced by the 'serve' subcommand.
invalid option: --server
