### PR TITLE
Remove CNAME to avoid HTTP hops

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-blog.rubygems.org


### PR DESCRIPTION
This simply prevents the HTTP-based 302 in an otherwise HTTPS only setup.

```
$ curl -i https://rubygems.github.io
HTTP/1.1 301 Moved Permanently
Server: GitHub.com
Content-Type: text/html
Location: http://blog.rubygems.org/
```

By removing the CNAME, we'll get a valid HTTPS response on this origin without the redirect.

This PR is predicated on the assumption that Fastly is set to use https://rubygems.github.io as the origin source for http[s]?://blog.rubygems.org.