### PR TITLE
Move meta charset on top of head element

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-us">
   <head>
+    <meta charset="UTF-8">
     {% if index %}
       <title>Blog - RubyGems</title>
     {% else %}
@@ -19,7 +20,6 @@
     <script type="text/javascript" src="/javascripts/application.js"></script>
     <script type="text/javascript" src="/javascripts/mobile-nav.js"></script>
     <script type="text/javascript" src="/javascripts/application.js"></script>
-    <meta charset="UTF-8">
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" name="viewport">
     <!--[if IE 8]>
       <script src="/assets/html5shiv.js"></script>


### PR DESCRIPTION
Hi,

This patch fix the error: `Error: A charset attribute on a meta element found after the first 1024 bytes.`

cf https://validator.nu/?doc=https%3A%2F%2Fblog.rubygems.org%2F&showsource=yes

Cheers;
Laurent