### PR TITLE
decrease spacing between words in code segments

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -351,6 +351,7 @@ a.t-list__item {
     word-break: normal; }
 .t-body code {
   font-weight: bold;
+  word-spacing: -0.3em;
   font-family: "courier", monospace; }
 .t-body ul, .t-body ol {
   margin-top: 18px; }


### PR DESCRIPTION
The monospace is  too spaced out and irritating to read, and this css fixes that.
Before:
<img width="541" alt="image" src="https://user-images.githubusercontent.com/44324811/185216911-9be8eed2-a147-4217-8b11-5fb0ae200171.png">

After:
<img width="530" alt="image" src="https://user-images.githubusercontent.com/44324811/185216547-710aa932-0a77-4243-96e4-4fdfeef988fc.png">
