### PR TITLE
Make mfa levels all backticked in UI Only removal blog post

### DIFF
--- a/_posts/2022-08-22-mfa-ui-only-removed.md
+++ b/_posts/2022-08-22-mfa-ui-only-removed.md
@@ -8,7 +8,7 @@ author_email: kevin.lin@shopify.com
 # Summary
 
 The `UI only` multi-factor authentication level is being removed.
-Users who remain on the UI only MFA level will be migrated to the UI and gem signin level on September 22nd, 2022.
+Users who remain on the `UI only` MFA level will be migrated to the `UI and gem signin` level on September 22nd, 2022.
 
 # Why is this happening?
 


### PR DESCRIPTION
I seemed to have forgotten to wrap these MFA levels in backticks, and this PR fixes it.
<img width="728" alt="image" src="https://user-images.githubusercontent.com/44324811/186218728-f3538f95-8808-43df-b042-73740d666966.png">
