### PR TITLE
Update header menu

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,9 +48,11 @@
           </form>
 
           <nav class="header__nav-links">
-            <a class="header__nav-link" href="http://rubygems.org/gems">Gems</a>
-            <a class="header__nav-link" href="http://guides.rubygems.org/">Guides</a>
-            <a class="header__nav-link" href="http://guides.rubygems.org/contributing/">Contribute</a>
+            <a class="header__nav-link" href="https://rubygems.org/releases">Releases</a>
+            <a class="header__nav-link is-active" href="/">Blog</a>
+            <a class="header__nav-link" href="https://rubygems.org/gems">Gems</a>
+            <a class="header__nav-link" href="https://guides.rubygems.org/">Guides</a>
+            <a class="header__nav-link" href="https://guides.rubygems.org/contributing/">Contribute</a>
           </nav>
         </div>
       </div>


### PR DESCRIPTION
- Update header menu links to more closely match rubygems.org, as outlined here:
[**RubyGems features:** UI Issue: Make Header Menu Consistent on Blog/Guides SubSites](https://github.com/orgs/rubygems/projects/6/views/1?pane=issue&itemId=18722655)
- Change `http://` nav links to `https://`
