### PR TITLE
Code pre blocks look strange when spaces are not the same size as the letters

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -351,7 +351,6 @@ a.t-list__item {
     word-break: normal; }
 .t-body code {
   font-weight: bold;
-  word-spacing: -0.3em;
   font-family: "courier", monospace; }
 .t-body ul, .t-body ol {
   margin-top: 18px; }


### PR DESCRIPTION
Before:

<img width="673" alt="Screenshot 2024-05-30 at 10 08 01 AM" src="https://github.com/rubygems/rubygems.github.io/assets/989/35c2c381-62c5-45b5-96d2-a14f15e1ab08">

After:

<img width="658" alt="Screenshot 2024-05-30 at 10 08 24 AM" src="https://github.com/rubygems/rubygems.github.io/assets/989/94ca51c7-a017-43cd-b3ab-d9bdd254a96e">
