### PR TITLE
Fix typo in 16 Dec 2024 3.6.0 Released post

### DIFF
--- a/_posts/2024-12-16-3.6.0-released.md
+++ b/_posts/2024-12-16-3.6.0-released.md
@@ -63,7 +63,7 @@ _## Documentation:_
 
 * Fix missing single quote in git source example. Pull request
   [#8303](https://github.com/rubygems/rubygems/pull/8303) by nobu
-* Update the `gem install` demo in REAME to use a gem that just works on
+* Update the `gem install` demo in README to use a gem that just works on
   Windows. Pull request
   [#8262](https://github.com/rubygems/rubygems/pull/8262) by soda92
 * Unify rubygems and bundler docs directory. Pull request


### PR DESCRIPTION
Changes `REAME` → `README` in the 16 Dec 2024 3.6.0 Released post at https://blog.rubygems.org/2024/12/16/3.6.0-released.html to better describe the effect of rubygems/rubygems#8262.

Proposed alongside rubygems/rubygems#8638.

---
Cheers, and thank you!